### PR TITLE
feat: Phase 27 — Timeline Snap + Caption Drag 🚀✨

### DIFF
--- a/frontend/src/TimelineEditor.css
+++ b/frontend/src/TimelineEditor.css
@@ -1,30 +1,49 @@
+/* src/TimelineEditor.css */
+
 .timeline-editor {
   padding: 1rem;
   text-align: center;
 }
 
-.timeline {
+.timeline-track {
   position: relative;
+  height: 50px;
+  background: linear-gradient(to right, #222, #333);
+  border-radius: 6px;
+  overflow: hidden;
   margin-top: 1rem;
-  height: 40px;
-  background: #f0f0f0;
-  border: 1px solid #ccc;
+  margin-bottom: 1rem;
+  border: 1px solid #555;
 }
 
 .caption-block {
   position: absolute;
   top: 5px;
-  height: 30px;
-  background: #8e44ad;
-  color: white;
+  height: 40px;
+  background-color: #3498db;
+  color: #fff;
   text-align: center;
-  line-height: 30px;
+  line-height: 40px;
   border-radius: 4px;
   cursor: grab;
   user-select: none;
-  padding: 0 5px;
+  transition: background-color 0.2s;
 }
 
 .caption-block.active {
-  background: #e67e22;
+  background-color: #2ecc71;
+}
+
+.marker {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 2px;
+  background-color: #f39c12;
+  opacity: 0.8;
+}
+
+.marker.active {
+  background-color: #e74c3c;
+  opacity: 1;
 }

--- a/frontend/src/TimelineEditor.jsx
+++ b/frontend/src/TimelineEditor.jsx
@@ -1,5 +1,9 @@
+// src/TimelineEditor.jsx
+
 import React from "react";
 import "./TimelineEditor.css";
+
+const SNAP_THRESHOLD = 0.1; // seconds
 
 function TimelineEditor({ projectData, onProjectDataChange }) {
   const handleVideoChange = (e) => {
@@ -13,6 +17,26 @@ function TimelineEditor({ projectData, onProjectDataChange }) {
     }
   };
 
+  const handleCaptionDrag = (index, newStart) => {
+    let snappedStart = newStart;
+
+    // Find nearest marker within SNAP_THRESHOLD
+    for (const marker of projectData.markers || []) {
+      if (Math.abs(marker.time - newStart) <= SNAP_THRESHOLD) {
+        snappedStart = marker.time;
+        break;
+      }
+    }
+
+    const updatedCaptions = [...projectData.captions];
+    const duration = updatedCaptions[index].end - updatedCaptions[index].start;
+
+    updatedCaptions[index].start = snappedStart;
+    updatedCaptions[index].end = snappedStart + duration;
+
+    onProjectDataChange({ ...projectData, captions: updatedCaptions });
+  };
+
   return (
     <div className="timeline-editor">
       <h2>🕒 Timeline Editor</h2>
@@ -24,7 +48,36 @@ function TimelineEditor({ projectData, onProjectDataChange }) {
           style={{ width: "100%", marginTop: "10px" }}
         />
       )}
-      {/* You can add captions editor here */}
+
+      <div className="timeline-track">
+        {projectData.markers?.map((marker, index) => (
+          <div
+            key={index}
+            className="marker"
+            style={{ left: `${marker.time * 50}px` }} // Example scaling: 50px per second
+          ></div>
+        ))}
+
+        {projectData.captions?.map((caption, index) => (
+          <div
+            key={index}
+            className="caption-block"
+            style={{
+              left: `${caption.start * 50}px`,
+              width: `${(caption.end - caption.start) * 50}px`,
+            }}
+            draggable
+            onDrag={(e) => {
+              const timelineRect = e.target.parentElement.getBoundingClientRect();
+              const newLeft = e.clientX - timelineRect.left;
+              const newStart = newLeft / 50; // scale factor
+              handleCaptionDrag(index, newStart);
+            }}
+          >
+            {caption.text}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 🚀 Phase 27 — Timeline Snap + Caption Drag 🚀✨

### What's New:

✅ Implemented **snap-to-marker** behavior for captions  
✅ Captions are now **draggable** along the timeline  
✅ Visual markers + captions track  
✅ Visual + UX polish for TimelineEditor  
✅ Refactored TimelineEditor.jsx for clean snapping logic  

### Testing:

✅ Manual test: captions snap to nearest marker  
✅ Captions preserve duration during drag  
✅ Video load/play works  
✅ Markers visually accurate  

---

#ai #timeline #phase27 #drag #snap #polish 🚀✨
